### PR TITLE
Imp/v2025.11 docker refresh

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,5 +26,5 @@
   "forwardPorts": [
     3000
   ],
-  "postCreateCommand": "bundle config set path '/usr/local/bundle' && corepack enable || true"
+  "postCreateCommand": "set -e; bundle config set path '/usr/local/bundle'; (rm -f /usr/local/bin/yarn /usr/local/bin/yarnpkg /usr/local/bin/pnpm || true && corepack enable) || true"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+{
+  "name": "Rails 8 + Node 24 + Postgres 18",
+  "dockerComposeFile": "../docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/work",
+  "runServices": [
+    "db",
+    "app"
+  ],
+  "remoteUser": "app",
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "installZsh": true,
+      "username": "app"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "Shopify.ruby-lsp",
+        "esbenp.prettier-vscode",
+        "ms-azuretools.vscode-docker"
+      ]
+    }
+  },
+  "forwardPorts": [
+    3000
+  ],
+  "postCreateCommand": "bundle config set path '/usr/local/bundle' && corepack enable || true"
+}

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+node_modules
+tmp
+log
+coverage
+storage
+.git
+.gitignore
+.vscode
+.devcontainer/.cache
+Dockerfile*
+docker-compose*.yml
+*.swp
+*.bak

--- a/.gitignore
+++ b/.gitignore
@@ -1,42 +1,42 @@
-# Ignore bundler config.
+# Bundler
 /.bundle
+/vendor/bundle
 
-# Ignore all logfiles and tempfiles.
+# Logs and tempfiles
 /log/*
 !/log/.keep
-/tmp
 /tmp/*
 !/tmp/.keep
-
-# Ignore uploaded files in development.
-/storage/*
-!/storage/.keep
-
-# Ignore cache directories.
 /tmp/pids
 /tmp/cache
 /tmp/sockets
 /tmp/uploads
 
-# Ignore development & test secrets
+# Active Storage
+/storage/*
+!/storage/.keep
+
+# Credentials
 /config/master.key
 /config/credentials.yml.enc
 
-# Ignore node_modules and yarn error log.
+# Node
 /node_modules
 /yarn-error.log
 
-# Ignore coverage directory.
+# Coverage & spec artifacts
 /coverage/
-
-# Ignore system specs results.
 /spec/examples.txt
 
-# Ignore the .git directory
-.git
-.gitignore
+# Compiled assets (if present)
+/public/assets
+/public/packs
+/public/packs-test
 
-# Ignore editor and OS-specific files
+# Byebug history
+.byebug_history
+
+# OS/editor
 **/.DS_Store
 **/Thumbs.db
 **/*.swp
@@ -45,16 +45,5 @@
 **/*~
 **/._*
 
-# Ignore the public/assets directory
-/public/assets
-/public/packs
-/public/packs-test
-/public/packs-dev
-/public/packs-test-dev
-
-# Ignore byebug history
-.byebug_history
-
-# Ignore Docker-related files (optional)
-Dockerfile*
-docker-compose*
+# Dev Container cache
+.devcontainer/.cache

--- a/Dockerfile.starter
+++ b/Dockerfile.starter
@@ -1,48 +1,67 @@
-FROM ruby:3.3.0-bullseye
+# syntax=docker/dockerfile:1
+
+# Stage: Node toolchain (to copy from)
+FROM node:24-bookworm AS node
+
+# Final stage: Ruby base
+FROM ruby:3.4-bookworm
 
 ARG USER_ID=1000
 ARG GROUP_ID=1000
 
-ENV BUNDLER_VERSION 2.5.11
-ENV RAILS_LOG_TO_STDOUT true
-ENV RAILS_ENV development
-ENV RAILS_SERVE_STATIC_FILES true
+ENV APP_PATH=/work \
+  RAILS_ENV=development \
+  RAILS_LOG_TO_STDOUT=true \
+  RAILS_SERVE_STATIC_FILES=true \
+  # Toolchain pins (as of Nov 2025)
+  BUNDLER_VERSION=2.7.2 \
+  RAILS_VERSION=8.1.1 \
+  # Bundler ergonomics
+  BUNDLE_JOBS=4 \
+  BUNDLE_RETRY=3 \
+  BUNDLE_PATH=/usr/local/bundle
 
+# System deps
 RUN apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-  build-essential \
-  git \
-  libxml2-dev \
-  libxslt-dev \
-  tzdata \
-  libpq-dev \
+  build-essential git curl tzdata \
+  libpq-dev libxml2-dev libxslt-dev libvips \
+  gnupg2 wget lsb-release ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 
-RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
-RUN apt-get install -y nodejs
-RUN npm install -g yarn
+# PostgreSQL client 18 via PGDG (apt-key is deprecated; use signed-by)
+RUN install -d /etc/apt/keyrings \
+  && wget -qO /etc/apt/keyrings/pgdg.gpg https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+  && sh -lc 'echo "deb [signed-by=/etc/apt/keyrings/pgdg.gpg] http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' \
+  && apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends postgresql-client-18 \
+  && rm -rf /var/lib/apt/lists/*
 
-RUN apt-get update && apt-get install -y gnupg2 wget lsb-release
+# Bundler & Rails
+RUN gem install bundler -v "${BUNDLER_VERSION}" \
+  && gem install rails -v "${RAILS_VERSION}"
 
-# Add the PostgreSQL PGP key to verify their Debian packages
-RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+# Bring Node/npm/npx/corepack from the Node stage
+COPY --from=node /usr/local/bin/node /usr/local/bin/node
+COPY --from=node /usr/local/bin/npm /usr/local/bin/npm
+COPY --from=node /usr/local/bin/npx /usr/local/bin/npx
+COPY --from=node /usr/local/bin/corepack /usr/local/bin/corepack
+COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
 
-# Add PostgreSQL's repository for the latest stable releases
-RUN sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+# Enable Corepack shims (Yarn/pnpm on demand)
+RUN corepack enable
 
-# Install PostgreSQL client version 16
-RUN apt-get update && apt-get install -y postgresql-client-16
+# App directory & source
+WORKDIR ${APP_PATH}
+COPY --chown=${USER_ID}:${GROUP_ID} . ${APP_PATH}
 
-# Install Bundler and Rails
-RUN gem install bundler -v $BUNDLER_VERSION
-RUN gem install rails
-
-ENV APP_PATH /work
-WORKDIR $APP_PATH
-ADD . $APP_PATH
-
-RUN echo "APP_PATH: [$APP_PATH]"
+# Non-root user
+RUN groupadd --gid ${GROUP_ID} app \
+  && useradd --uid ${USER_ID} --gid ${GROUP_ID} --create-home app \
+  && chown -R app:app ${APP_PATH} /usr/local/bundle
+USER app
 
 EXPOSE 3000
 
-ENTRYPOINT ["tail", "-f", "/dev/null"]
+# If the Rails app isn't generated yet, keep the container alive for interactive use.
+CMD bash -lc 'if [ -x ./bin/dev ]; then ./bin/dev; else echo "No bin/dev yet (generate the app with: rails new . ...)."; tail -f /dev/null; fi'

--- a/Dockerfile.starter
+++ b/Dockerfile.starter
@@ -29,10 +29,13 @@ RUN apt-get update && \
   gnupg2 wget lsb-release ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 
-# PostgreSQL client 18 via PGDG (apt-key is deprecated; use signed-by)
-RUN install -d /etc/apt/keyrings \
-  && wget -qO /etc/apt/keyrings/pgdg.gpg https://www.postgresql.org/media/keys/ACCC4CF8.asc \
-  && sh -lc 'echo "deb [signed-by=/etc/apt/keyrings/pgdg.gpg] http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' \
+# PostgreSQL client 18 via PGDG (use dearmored keyring with signed-by)
+RUN install -d /usr/share/keyrings \
+  && curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+  | gpg --dearmor -o /usr/share/keyrings/postgresql.gpg \
+  && chmod 0644 /usr/share/keyrings/postgresql.gpg \
+  && echo "deb [signed-by=/usr/share/keyrings/postgresql.gpg] http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" \
+  > /etc/apt/sources.list.d/pgdg.list \
   && apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends postgresql-client-18 \
   && rm -rf /var/lib/apt/lists/*
@@ -42,14 +45,14 @@ RUN gem install bundler -v "${BUNDLER_VERSION}" \
   && gem install rails -v "${RAILS_VERSION}"
 
 # Bring Node/npm/npx/corepack from the Node stage
-COPY --from=node /usr/local/bin/node /usr/local/bin/node
-COPY --from=node /usr/local/bin/npm /usr/local/bin/npm
-COPY --from=node /usr/local/bin/npx /usr/local/bin/npx
-COPY --from=node /usr/local/bin/corepack /usr/local/bin/corepack
-COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
+# Bring the full Node toolchain (preserves corepack layout & symlinks)
+COPY --from=node /usr/local/ /usr/local/
 
-# Enable Corepack shims (Yarn/pnpm on demand)
-RUN corepack enable
+# Enable Corepack shims (Yarn/pnpm) idempotently: remove stale links, then enable (use bash)
+RUN bash -lc 'if command -v corepack >/dev/null 2>&1; then \
+  rm -f /usr/local/bin/yarn /usr/local/bin/yarnpkg /usr/local/bin/pnpm || true; \
+  corepack enable; \
+  fi'
 
 # App directory & source
 WORKDIR ${APP_PATH}

--- a/README.md
+++ b/README.md
@@ -1,19 +1,36 @@
-## Rails get started with Docker and Postgres
+# Rails + Docker + Postgres Starter (2025‑11)
 
-This is a blank project to get started with Rails, Docker and Postgres. Once you get the Rails app going please change the Dockerfile and docker-compose.yml to suit your needs.
+This starter uses **Ruby 3.4 (Debian bookworm slim)**, **Rails 8.1**, **Node 24 LTS (Corepack)**, and **PostgreSQL 18**.
 
-## To build
+> TL;DR  
+> ```bash
+> docker compose build
+> docker compose up -d db
+> docker compose run --rm app rails new . --force --database=postgresql
+> docker compose up
+> ```
+> Then visit http://localhost:3000
+
+---
+
+or ie:
+docker compose run --rm app rails new . --force --database=postgresql --css=tailwind --javascript=importmap
+
+
+## 1) Build and boot
 
 ```bash
+# Build images
 docker compose build
-docker compose up
-```
 
-Then go to docker desktop
-Find the container and open a shell and type
+# Start Postgres first
+docker compose up -d db
 
-# create a new rails app with postgres
 
-```bash
-rails new . --force --database=postgresql
-```
+Good commands
+docker compose run --rm app bin/rails db:migrate
+docker compose run --rm app bin/rails g scaffold Post title:string
+
+# Console & tests
+docker compose run --rm app bin/rails console
+docker compose run --rm app bin/rspec 

--- a/README.md
+++ b/README.md
@@ -2,23 +2,7 @@
 
 This starter uses **Ruby 3.4 (Debian bookworm slim)**, **Rails 8.1**, **Node 24 LTS (Corepack)**, and **PostgreSQL 18**.
 
-> TL;DR  
-> ```bash
-> docker compose build
-> docker compose up -d db
-> docker compose run --rm app rails new . --force --database=postgresql
-> docker compose up
-> ```
-> Then visit http://localhost:3000
-
----
-
-or ie:
-docker compose run --rm app rails new . --force --database=postgresql --css=tailwind --javascript=importmap
-
-
-## 1) Build and boot
-
+## Quick Start
 ```bash
 # Build images
 docker compose build
@@ -26,11 +10,122 @@ docker compose build
 # Start Postgres first
 docker compose up -d db
 
+# Generate your Rails app (choose one option below)
+docker compose run --rm app rails new . --force --database=postgresql
 
-Good commands
+# Start the app
+docker compose up
+```
+
+Then visit http://localhost:3000
+
+---
+
+## Rails App Generation Options
+
+Choose the setup that fits your needs:
+```bash
+# Minimal setup (API mode)
+docker compose run --rm app rails new . --force --database=postgresql
+
+# With Tailwind CSS
+docker compose run --rm app rails new . --force --database=postgresql --css=tailwind
+
+# With importmap (no build step)
+docker compose run --rm app rails new . --force --database=postgresql --javascript=importmap
+
+# Full-stack with Tailwind + importmap
+docker compose run --rm app rails new . --force --database=postgresql --css=tailwind --javascript=importmap
+
+# With esbuild (modern JS bundling)
+docker compose run --rm app rails new . --force --database=postgresql --javascript=esbuild
+```
+
+---
+
+## Common Commands
+
+### Database Operations
+```bash
+# Create databases
+docker compose run --rm app bin/rails db:create
+
+# Run migrations
 docker compose run --rm app bin/rails db:migrate
-docker compose run --rm app bin/rails g scaffold Post title:string
 
-# Console & tests
+# Rollback last migration
+docker compose run --rm app bin/rails db:rollback
+
+# Load schema
+docker compose run --rm app bin/rails db:schema:load
+
+# Seed database
+docker compose run --rm app bin/rails db:seed
+
+# Reset database (drop, create, migrate, seed)
+docker compose run --rm app bin/rails db:reset
+```
+
+### Generators
+```bash
+# Generate a scaffold
+docker compose run --rm app bin/rails g scaffold Post title:string body:text published:boolean
+
+# Generate a model
+docker compose run --rm app bin/rails g model User email:string name:string
+
+# Generate a controller
+docker compose run --rm app bin/rails g controller Pages home about contact
+
+# Generate a migration
+docker compose run --rm app bin/rails g migration AddSlugToPosts slug:string:index
+```
+
+### Development Tools
+```bash
+# Rails console
 docker compose run --rm app bin/rails console
-docker compose run --rm app bin/rspec 
+
+# Run tests
+docker compose run --rm app bin/rails test
+
+# Run RSpec (if installed)
+docker compose run --rm app bin/rspec
+
+# Rails routes
+docker compose run --rm app bin/rails routes
+
+# Rails stats
+docker compose run --rm app bin/rails stats
+```
+
+### Credentials & Secrets
+```bash
+# Edit credentials (uses $EDITOR, default: vi)
+docker compose run --rm app bin/rails credentials:edit
+
+# Show credentials
+docker compose run --rm app bin/rails credentials:show
+```
+
+### Bundle & Dependencies
+```bash
+# Install gems
+docker compose run --rm app bundle install
+
+# Update a specific gem
+docker compose run --rm app bundle update rails
+
+# Add a gem (edit Gemfile first, then:)
+docker compose run --rm app bundle install
+
+# Install JS dependencies (if using npm/yarn)
+docker compose run --rm app yarn install
+```
+
+### Container Management
+```bash
+# View logs
+docker compose logs -f app
+
+# Restart services

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       RAILS_LOG_TO_STDOUT: "true"
       RAILS_SERVE_STATIC_FILES: "true"
       DATABASE_URL: postgres://postgres:postgres@db:5432/app_development
+      BUNDLE_PATH: /usr/local/bundle
     volumes:
       - .:/work:delegated
       - bundle:/usr/local/bundle

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,44 @@
 services:
-  cache:
-    image: busybox
-    tty: true
+  db:
+    image: postgres:18
+    environment:
+      POSTGRES_DB: app_development
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      # PG 18+ uses a versioned default path inside the image; set explicitly for clarity
+      PGDATA: /var/lib/postgresql/18/docker
     volumes:
-      - /npm_cache
+      - pgdata:/var/lib/postgresql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB -h localhost"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 10s
+
   app:
     build:
       context: .
       dockerfile: Dockerfile.starter
+      args:
+        USER_ID: ${UID:-1000}
+        GROUP_ID: ${GID:-1000}
+    environment:
+      RAILS_ENV: development
+      RAILS_LOG_TO_STDOUT: "true"
+      RAILS_SERVE_STATIC_FILES: "true"
+      DATABASE_URL: postgres://postgres:postgres@db:5432/app_development
+    volumes:
+      - .:/work:delegated
+      - bundle:/usr/local/bundle
     ports:
       - "3000:3000"
-    volumes:
-      - .:/work
-    volumes_from:
-      - cache
+    depends_on:
+      db:
+        condition: service_healthy
+    tty: true
+    stdin_open: true
+
+volumes:
+  bundle:
+  pgdata:


### PR DESCRIPTION
Modernizes the Rails starter template for November 2025.

Upgrades base images to Ruby 3.4, Node 24 (LTS), and PostgreSQL 18
Adds fully configured Dev Container for VS Code
Improves Dockerfile reliability (PG key handling, non-root user, Corepack idempotency)
Updates .vscode defaults, .dockerignore, and documentation for developer onboarding
Optimised for faster builds, cleaner context, and consistent DX across macOS, Linux, and Windows